### PR TITLE
Switched from Broadcast to unagi-chan, which doesn't drop messages

### DIFF
--- a/haskell/hs-websocket-server.cabal
+++ b/haskell/hs-websocket-server.cabal
@@ -20,9 +20,8 @@ executable hs-websocket-server
   build-depends:       base >= 4.7 && < 5
                      , aeson
                      , async
-                     , broadcast-chan
                      , bytestring
-                     , concurrent-extra
+                     , unagi-chan
                      , containers
                      , http-types
                      , lens

--- a/haskell/stack.yaml
+++ b/haskell/stack.yaml
@@ -3,7 +3,8 @@ resolver: lts-6.14
 packages:
 - '.'
 
-extra-deps: []
+extra-deps:
+- unagi-chan-0.4.0.0
 
 flags: {}
 


### PR DESCRIPTION
I'm not sure how this performs now, haven't really got the benchmarks to run on my machine reliably.

I decided to use unagi-chan instead of broadcast-chan because of its focus on performance, but for no particularly good other reason.

Also this doesn't contain the fixes discussed in https://github.com/hashrocket/websocket-shootout/pull/14#issuecomment-244551430 and implemented in #2  yet.